### PR TITLE
feat : PostDetail 구현

### DIFF
--- a/src/components/PostDetail/PostDetail.module.css
+++ b/src/components/PostDetail/PostDetail.module.css
@@ -69,6 +69,12 @@
   cursor: pointer;
 }
 
+.post__edit a {
+  color: gray;
+  text-decoration: none;
+  font-size: 14px;
+}
+
 .post__delete:focus,
 .post__delete:hover,
 .post__edit:focus,

--- a/src/components/PostDetail/PostDetail.module.css
+++ b/src/components/PostDetail/PostDetail.module.css
@@ -1,0 +1,87 @@
+.post__detail {
+  min-height: 90vh;
+  max-width: 680px;
+  padding: 20px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+.post__box {
+  padding-top: 24px;
+  padding-bottom: 24px;
+  border-top: 1px solid #f2f2f2;
+}
+
+.post__title {
+  font-size: 36px;
+  line-height: 40px;
+  font-weight: 600;
+  margin: 14px 0;
+}
+
+.post__profile__box {
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  gap: 9px;
+  padding: 10px 0px;
+}
+
+.post__profile {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: lightgrey;
+}
+
+.post__author__email,
+.post__date {
+  color: gray;
+}
+
+.post__utils__box {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 14px;
+  color: gray;
+  padding: 10px 0px;
+  border-top: 1px solid #f2f2f2;
+  border-bottom: 1px solid #f2f2f2;
+}
+
+.post__category {
+  color: gray;
+  border: 1px solid lightgray;
+  background: #f2f2f2;
+  padding: 2px 4px;
+  border-radius: 10px;
+  font-size: 12px;
+}
+
+.post__edit__box {
+  width: 13%;
+  display: flex;
+  justify-content: space-around;
+}
+.post__delete,
+.post__edit {
+  cursor: pointer;
+}
+
+.post__delete:focus,
+.post__delete:hover,
+.post__edit:focus,
+.post__edit:hover {
+  color: black;
+}
+
+.post__text {
+  color: #39211d;
+  font-size: 17px;
+  padding: 20px 0px;
+}
+
+.post__text__preWrap {
+  white-space: pre-wrap;
+}

--- a/src/components/PostDetail/PostDetail.tsx
+++ b/src/components/PostDetail/PostDetail.tsx
@@ -1,14 +1,24 @@
 import { useEffect, useState } from "react";
 import styles from "./PostDetail.module.css";
 import { PostProps } from "../../typings/post.types";
-import { useParams } from "react-router";
-import { getPost } from "../../firebaseApp";
+import { useNavigate, useParams } from "react-router";
+import { deletePost, getPost } from "../../firebaseApp";
 import { Link } from "react-router-dom";
 
 export default function PostDetail() {
   const [post, setPost] = useState<PostProps | null>(null);
 
   const params = useParams();
+  const navigate = useNavigate();
+
+  const handleDelete = async (id: string) => {
+    const confirm = window.confirm("해당 게시글을 삭제 하시겠습니까?");
+
+    if (confirm && id) {
+      deletePost(id);
+      navigate("/");
+    }
+  };
 
   useEffect(() => {
     if (params?.id) getPost(params?.id, setPost);
@@ -27,7 +37,11 @@ export default function PostDetail() {
       <div className={styles.post__utils__box}>
         <div className={styles.post__category}>{post?.category}</div>
         <div className={styles.post__edit__box}>
-          <div className={styles.post__delete}>delete</div>
+          <div
+            className={styles.post__delete}
+            onClick={() => handleDelete(post?.id as string)}>
+            삭제
+          </div>
           <div className={styles.post__edit}>
             <Link to={`/posts/edit/${post?.id}`}>수정</Link>
           </div>

--- a/src/components/PostDetail/PostDetail.tsx
+++ b/src/components/PostDetail/PostDetail.tsx
@@ -1,25 +1,37 @@
+import { useEffect, useState } from "react";
 import styles from "./PostDetail.module.css";
+import { PostProps } from "../../typings/post.types";
+import { useParams } from "react-router";
+import { getPost } from "../../firebaseApp";
 
 export default function PostDetail() {
+  const [post, setPost] = useState<PostProps | null>(null);
+
+  const params = useParams();
+
+  useEffect(() => {
+    if (params?.id) getPost(params?.id, setPost);
+  }, [params?.id]);
+
   return (
     <div className={styles.post__detail}>
       <div className={styles.post__box}>
-        <div className={styles.post__title}>title</div>
+        <div className={styles.post__title}>{post?.title}</div>
         <div className={styles.post__profile__box}>
           <div className={styles.post__profile} />
-          <div className={styles.post__author__email}>email</div>
-          <div className={styles.post__date}>2024-04-29</div>
+          <div className={styles.post__author__email}>{post?.email}</div>
+          <div className={styles.post__date}>{post?.createdAt}</div>
         </div>
       </div>
       <div className={styles.post__utils__box}>
-        <div className={styles.post__category}>category</div>
+        <div className={styles.post__category}>{post?.category}</div>
         <div className={styles.post__edit__box}>
           <div className={styles.post__delete}>delete</div>
           <div className={styles.post__edit}>edit</div>
         </div>
       </div>
       <div className={`${styles.post__text} ${styles.post__text__preWrap}`}>
-        content
+        {post?.content}
       </div>
     </div>
   );

--- a/src/components/PostDetail/PostDetail.tsx
+++ b/src/components/PostDetail/PostDetail.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
-import styles from "./PostDetail.module.css";
-import { PostProps } from "../../typings/post.types";
+import { Link } from "react-router-dom";
 import { useNavigate, useParams } from "react-router";
 import { deletePost, getPost } from "../../firebaseApp";
-import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { PostProps } from "../../typings/post.types";
+import styles from "./PostDetail.module.css";
 
 export default function PostDetail() {
   const [post, setPost] = useState<PostProps | null>(null);

--- a/src/components/PostDetail/PostDetail.tsx
+++ b/src/components/PostDetail/PostDetail.tsx
@@ -3,6 +3,7 @@ import styles from "./PostDetail.module.css";
 import { PostProps } from "../../typings/post.types";
 import { useParams } from "react-router";
 import { getPost } from "../../firebaseApp";
+import { Link } from "react-router-dom";
 
 export default function PostDetail() {
   const [post, setPost] = useState<PostProps | null>(null);
@@ -27,7 +28,9 @@ export default function PostDetail() {
         <div className={styles.post__category}>{post?.category}</div>
         <div className={styles.post__edit__box}>
           <div className={styles.post__delete}>delete</div>
-          <div className={styles.post__edit}>edit</div>
+          <div className={styles.post__edit}>
+            <Link to={`/posts/edit/${post?.id}`}>수정</Link>
+          </div>
         </div>
       </div>
       <div className={`${styles.post__text} ${styles.post__text__preWrap}`}>

--- a/src/components/PostDetail/PostDetail.tsx
+++ b/src/components/PostDetail/PostDetail.tsx
@@ -1,20 +1,26 @@
+import styles from "./PostDetail.module.css";
+
 export default function PostDetail() {
   return (
-    <div>
-      <div>
-        <div>title</div>
-        <div>
-          <div>profile</div>
-          <div>email</div>
-          <div>2024-04-29</div>
+    <div className={styles.post__detail}>
+      <div className={styles.post__box}>
+        <div className={styles.post__title}>title</div>
+        <div className={styles.post__profile__box}>
+          <div className={styles.post__profile} />
+          <div className={styles.post__author__email}>email</div>
+          <div className={styles.post__date}>2024-04-29</div>
         </div>
       </div>
-      <div>
-        <div>category</div>
-        <div>delete</div>
-        <div>edit</div>
+      <div className={styles.post__utils__box}>
+        <div className={styles.post__category}>category</div>
+        <div className={styles.post__edit__box}>
+          <div className={styles.post__delete}>delete</div>
+          <div className={styles.post__edit}>edit</div>
+        </div>
       </div>
-      <div>content</div>
+      <div className={`${styles.post__text} ${styles.post__text__preWrap}`}>
+        content
+      </div>
     </div>
   );
 }

--- a/src/components/PostDetail/PostDetail.tsx
+++ b/src/components/PostDetail/PostDetail.tsx
@@ -1,0 +1,20 @@
+export default function PostDetail() {
+  return (
+    <div>
+      <div>
+        <div>title</div>
+        <div>
+          <div>profile</div>
+          <div>email</div>
+          <div>2024-04-29</div>
+        </div>
+      </div>
+      <div>
+        <div>category</div>
+        <div>delete</div>
+        <div>edit</div>
+      </div>
+      <div>content</div>
+    </div>
+  );
+}

--- a/src/components/PostList/PostList.tsx
+++ b/src/components/PostList/PostList.tsx
@@ -7,7 +7,10 @@ import UseGetPosts from "../../hooks/UseGetPosts";
 import { CategoryType, PostListProps, TabType } from "../../typings/post.types";
 import styles from "./PostList.module.css";
 
-export default function PostList({ defaultTab = "all" }: PostListProps) {
+export default function PostList({
+  hasNavigation = true,
+  defaultTab = "all",
+}: PostListProps) {
   const [activeTab, setActiveTab] = useState<TabType | CategoryType>(
     defaultTab
   );
@@ -30,10 +33,12 @@ export default function PostList({ defaultTab = "all" }: PostListProps) {
 
   return (
     <>
-      <Category
-        activeTab={activeTab}
-        handleChangeActiveTab={handleChangeActiveTab}
-      />
+      {hasNavigation && (
+        <Category
+          activeTab={activeTab}
+          handleChangeActiveTab={handleChangeActiveTab}
+        />
+      )}
       <div className={styles.post__list}>
         {posts.length > 0 ? (
           posts.map((post) => (

--- a/src/pages/posts/PostDetailPage.tsx
+++ b/src/pages/posts/PostDetailPage.tsx
@@ -1,3 +1,5 @@
+import PostDetail from "../../components/PostDetail/PostDetail";
+
 export default function PostDetailPage() {
-  return <div>Detail</div>;
+  return <PostDetail />;
 }

--- a/src/pages/posts/PostPage.tsx
+++ b/src/pages/posts/PostPage.tsx
@@ -1,3 +1,5 @@
+import PostList from "../../components/PostList/PostList";
+
 export default function PostPage() {
-  return <div>Post Page</div>;
+  return <PostList hasNavigation={false} />;
 }

--- a/src/typings/post.types.ts
+++ b/src/typings/post.types.ts
@@ -21,6 +21,7 @@ export interface PostProps {
 }
 
 export interface PostListProps {
+  hasNavigation?: boolean;
   defaultTab?: TabType | CategoryType;
   activeTab?: TabType | CategoryType;
   handleChangeActiveTab?: (tab: CategoryType | TabType) => void;


### PR DESCRIPTION
## 작업내용

1. PostDetail 컴포넌트 구현
- 게시물 클릭하면 상세 페이지로 이동
- 상세 페이지에서 수정 페이지로 이동 구현
- 상세 페이지에서 삭제 구현 ( 삭제시 메인 페이지로 이동 )

2. 게시물 페이지 수정
- 카테고리 없이 게시물 불러옴

  <br/>

## 이미지 첨부

<p align="center">
<img width="80%"  height="50%" alt="스크린샷 2024-04-29 오후 6 36 36" src="https://github.com/jm-316/blog-project/assets/130331748/7c0955db-0555-4129-b298-faa72ac60f3e">
</p>
<p align="center">
<img width="80%" height="50%" alt="스크린샷 2024-04-29 오후 6 36 46" src="https://github.com/jm-316/blog-project/assets/130331748/c3d9bee3-ec54-4a27-88ef-e013ed653f10">
</p>

<br/>

## 앞으로의 과제

- 마이페이지 구현

  <br/>
