### PR TITLE
feat : comment 구현

### DIFF
--- a/src/CommentList/CommentList.module.css
+++ b/src/CommentList/CommentList.module.css
@@ -1,0 +1,35 @@
+.comment__box {
+  padding: 12px 0px;
+  border-bottom: 1px solid #f2f2f2;
+}
+
+.comment__profileBox {
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  gap: 10px;
+}
+
+.comment__email {
+  font-weight: 500;
+}
+
+.comment__delete {
+  color: gray;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.comment__delete:hover,
+.comment__delete:focus {
+  color: black;
+}
+
+.comment__date {
+  color: gray;
+}
+
+.comment__text {
+  font-size: 14px;
+  padding-top: 5px;
+}

--- a/src/CommentList/CommentList.tsx
+++ b/src/CommentList/CommentList.tsx
@@ -1,13 +1,11 @@
-import { User } from "firebase/auth";
-import { PostProps } from "../typings/post.types";
+import { CommentListProps } from "../typings/post.types";
 import styles from "./CommentList.module.css";
 
-interface CommentListProps {
-  post: PostProps;
-  user: User | null;
-}
-
-export default function CommentList({ post, user }: CommentListProps) {
+export default function CommentList({
+  post,
+  user,
+  handleDeleteComment,
+}: CommentListProps) {
   return (
     <div>
       {post?.comments
@@ -19,7 +17,11 @@ export default function CommentList({ post, user }: CommentListProps) {
               <div className={styles.comment__email}>{comment?.email}</div>
               <div className={styles.comment__date}>{comment?.createdAt}</div>
               {comment.uid === user?.uid && (
-                <div className={styles.comment__delete}>삭제</div>
+                <div
+                  className={styles.comment__delete}
+                  onClick={() => handleDeleteComment(comment)}>
+                  삭제
+                </div>
               )}
             </div>
             <div className={styles.comment__text}>{comment?.content}</div>

--- a/src/CommentList/CommentList.tsx
+++ b/src/CommentList/CommentList.tsx
@@ -1,0 +1,30 @@
+import { User } from "firebase/auth";
+import { PostProps } from "../typings/post.types";
+import styles from "./CommentList.module.css";
+
+interface CommentListProps {
+  post: PostProps;
+  user: User | null;
+}
+
+export default function CommentList({ post, user }: CommentListProps) {
+  return (
+    <div>
+      {post?.comments
+        ?.slice(0)
+        ?.reverse()
+        .map((comment) => (
+          <div key={comment.createdAt} className={styles.comment__box}>
+            <div className={styles.comment__profileBox}>
+              <div className={styles.comment__email}>{comment?.email}</div>
+              <div className={styles.comment__date}>{comment?.createdAt}</div>
+              {comment.uid === user?.uid && (
+                <div className={styles.comment__delete}>삭제</div>
+              )}
+            </div>
+            <div className={styles.comment__text}>{comment?.content}</div>
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/src/components/Comments/Comments.module.css
+++ b/src/components/Comments/Comments.module.css
@@ -45,39 +45,3 @@ textarea {
 .comment__btn:hover {
   background-color: #1945a4;
 }
-
-.comment__box {
-  padding: 12px 0px;
-  border-bottom: 1px solid #f2f2f2;
-}
-
-.comment__profileBox {
-  display: flex;
-  align-items: center;
-  font-size: 12px;
-  gap: 10px;
-}
-
-.comment__email {
-  font-weight: 500;
-}
-
-.comment__delete {
-  color: gray;
-  font-size: 12px;
-  cursor: pointer;
-}
-
-.comment__delete:hover,
-.comment__delete:focus {
-  color: black;
-}
-
-.comment__date {
-  color: gray;
-}
-
-.comment__text {
-  font-size: 14px;
-  padding-top: 5px;
-}

--- a/src/components/Comments/Comments.module.css
+++ b/src/components/Comments/Comments.module.css
@@ -45,3 +45,39 @@ textarea {
 .comment__btn:hover {
   background-color: #1945a4;
 }
+
+.comment__box {
+  padding: 12px 0px;
+  border-bottom: 1px solid #f2f2f2;
+}
+
+.comment__profileBox {
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  gap: 10px;
+}
+
+.comment__email {
+  font-weight: 500;
+}
+
+.comment__delete {
+  color: gray;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.comment__delete:hover,
+.comment__delete:focus {
+  color: black;
+}
+
+.comment__date {
+  color: gray;
+}
+
+.comment__text {
+  font-size: 14px;
+  padding-top: 5px;
+}

--- a/src/components/Comments/Comments.module.css
+++ b/src/components/Comments/Comments.module.css
@@ -1,0 +1,47 @@
+.comments {
+  width: 100%;
+  border-bottom: 1px solid lightgray;
+}
+
+label {
+  display: block;
+  margin-top: 20px;
+  margin-bottom: 10px;
+  font-weight: 600;
+}
+
+.form__block {
+  margin-top: 10px;
+  width: 100%;
+  height: 100%;
+}
+
+textarea {
+  max-width: 680px;
+  min-height: 100px;
+  width: 100%;
+  padding: 10px;
+  font-size: 16px;
+  line-height: 1.5;
+  border: 1px solid lightgray;
+  border-radius: 0.3rem;
+  display: block;
+}
+
+.comment__btn {
+  width: 90px;
+  height: 36px;
+  font-weight: 500;
+  background-color: #2563eb;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  margin-top: 10px;
+  margin-bottom: 20px;
+  cursor: pointer;
+}
+
+.comment__btn:focus,
+.comment__btn:hover {
+  background-color: #1945a4;
+}

--- a/src/components/Comments/Comments.tsx
+++ b/src/components/Comments/Comments.tsx
@@ -65,6 +65,21 @@ export default function Comments({ post, setPost }: CommentsProps) {
         </div>
         <button className={styles.comment__btn}>입력</button>
       </form>
+      <div>
+        {post?.comments
+          ?.slice(0)
+          ?.reverse()
+          .map((comment) => (
+            <div key={comment.createdAt}>
+              <div>
+                <div>{comment?.email}</div>
+                <div>{comment?.createdAt}</div>
+                {comment.uid === user?.uid && <div>삭제</div>}
+              </div>
+              <div>{comment?.content}</div>
+            </div>
+          ))}
+      </div>
     </div>
   );
 }

--- a/src/components/Comments/Comments.tsx
+++ b/src/components/Comments/Comments.tsx
@@ -70,13 +70,15 @@ export default function Comments({ post, setPost }: CommentsProps) {
           ?.slice(0)
           ?.reverse()
           .map((comment) => (
-            <div key={comment.createdAt}>
-              <div>
-                <div>{comment?.email}</div>
-                <div>{comment?.createdAt}</div>
-                {comment.uid === user?.uid && <div>삭제</div>}
+            <div key={comment.createdAt} className={styles.comment__box}>
+              <div className={styles.comment__profileBox}>
+                <div className={styles.comment__email}>{comment?.email}</div>
+                <div className={styles.comment__date}>{comment?.createdAt}</div>
+                {comment.uid === user?.uid && (
+                  <div className={styles.comment__delete}>삭제</div>
+                )}
               </div>
-              <div>{comment?.content}</div>
+              <div className={styles.comment__text}>{comment?.content}</div>
             </div>
           ))}
       </div>

--- a/src/components/Comments/Comments.tsx
+++ b/src/components/Comments/Comments.tsx
@@ -1,8 +1,9 @@
 import React, { useContext, useState } from "react";
-import { createComment } from "../../firebaseApp";
+import { createComment, getPost } from "../../firebaseApp";
 import AuthContext from "../../context/AuthContext";
 import { PostProps } from "../../typings/post.types";
 import styles from "./Comments.module.css";
+import CommentList from "../../CommentList/CommentList";
 
 interface CommentsProps {
   post: PostProps;
@@ -40,6 +41,7 @@ export default function Comments({ post, setPost }: CommentsProps) {
           };
 
           await createComment(post.id, commentObj);
+          await getPost(post.id, setPost);
 
           setComment("");
         } else {
@@ -66,21 +68,7 @@ export default function Comments({ post, setPost }: CommentsProps) {
         <button className={styles.comment__btn}>입력</button>
       </form>
       <div>
-        {post?.comments
-          ?.slice(0)
-          ?.reverse()
-          .map((comment) => (
-            <div key={comment.createdAt} className={styles.comment__box}>
-              <div className={styles.comment__profileBox}>
-                <div className={styles.comment__email}>{comment?.email}</div>
-                <div className={styles.comment__date}>{comment?.createdAt}</div>
-                {comment.uid === user?.uid && (
-                  <div className={styles.comment__delete}>삭제</div>
-                )}
-              </div>
-              <div className={styles.comment__text}>{comment?.content}</div>
-            </div>
-          ))}
+        <CommentList post={post} user={user} />
       </div>
     </div>
   );

--- a/src/components/Comments/Comments.tsx
+++ b/src/components/Comments/Comments.tsx
@@ -52,8 +52,7 @@ export default function Comments({ post, setPost }: CommentsProps) {
     const confirm = window.confirm("해당 댓글을 삭제하시겠습니까?");
 
     if (confirm && post.id) {
-      deleteComment(post.id, data);
-
+      await deleteComment(post.id, data);
       await getPost(post.id, setPost);
     }
   };

--- a/src/components/Comments/Comments.tsx
+++ b/src/components/Comments/Comments.tsx
@@ -1,14 +1,9 @@
 import React, { useContext, useState } from "react";
-import { createComment, getPost } from "../../firebaseApp";
+import { createComment, deleteComment, getPost } from "../../firebaseApp";
 import AuthContext from "../../context/AuthContext";
-import { PostProps } from "../../typings/post.types";
-import styles from "./Comments.module.css";
 import CommentList from "../../CommentList/CommentList";
-
-interface CommentsProps {
-  post: PostProps;
-  setPost: React.Dispatch<React.SetStateAction<PostProps | null>>;
-}
+import { CommentsInterface, CommentsProps } from "../../typings/post.types";
+import styles from "./Comments.module.css";
 
 export default function Comments({ post, setPost }: CommentsProps) {
   const [comment, setComment] = useState<string>("");
@@ -52,6 +47,16 @@ export default function Comments({ post, setPost }: CommentsProps) {
       console.log(error);
     }
   };
+
+  const handleDeleteComment = async (data: CommentsInterface) => {
+    const confirm = window.confirm("해당 댓글을 삭제하시겠습니까?");
+
+    if (confirm && post.id) {
+      deleteComment(post.id, data);
+
+      await getPost(post.id, setPost);
+    }
+  };
   return (
     <div className={styles.comments}>
       <form onSubmit={handleSubmit}>
@@ -68,7 +73,11 @@ export default function Comments({ post, setPost }: CommentsProps) {
         <button className={styles.comment__btn}>입력</button>
       </form>
       <div>
-        <CommentList post={post} user={user} />
+        <CommentList
+          post={post}
+          user={user}
+          handleDeleteComment={handleDeleteComment}
+        />
       </div>
     </div>
   );

--- a/src/components/Comments/Comments.tsx
+++ b/src/components/Comments/Comments.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router";
 import React, { useContext, useState } from "react";
 import { createComment, deleteComment, getPost } from "../../firebaseApp";
 import AuthContext from "../../context/AuthContext";
@@ -9,6 +10,8 @@ export default function Comments({ post, setPost }: CommentsProps) {
   const [comment, setComment] = useState<string>("");
 
   const { user } = useContext(AuthContext);
+
+  const navigate = useNavigate();
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { name, value } = e.target;
@@ -40,7 +43,8 @@ export default function Comments({ post, setPost }: CommentsProps) {
 
           setComment("");
         } else {
-          alert("로그인을 해주세요.");
+          alert("로그인 페이지로 이동합니다.");
+          navigate("/login");
         }
       }
     } catch (error) {

--- a/src/components/Comments/Comments.tsx
+++ b/src/components/Comments/Comments.tsx
@@ -1,12 +1,14 @@
+import styles from "./Comments.module.css";
+
 export default function Comments() {
   return (
-    <div>
+    <div className={styles.comments}>
       <form>
-        <div>
+        <div className={styles.form__block}>
           <label>댓글입력</label>
           <textarea />
         </div>
-        <button>입력</button>
+        <button className={styles.comment__btn}>입력</button>
       </form>
     </div>
   );

--- a/src/components/Comments/Comments.tsx
+++ b/src/components/Comments/Comments.tsx
@@ -1,12 +1,67 @@
+import React, { useContext, useState } from "react";
+import { createComment } from "../../firebaseApp";
+import AuthContext from "../../context/AuthContext";
+import { PostProps } from "../../typings/post.types";
 import styles from "./Comments.module.css";
 
-export default function Comments() {
+interface CommentsProps {
+  post: PostProps;
+  setPost: React.Dispatch<React.SetStateAction<PostProps | null>>;
+}
+
+export default function Comments({ post, setPost }: CommentsProps) {
+  const [comment, setComment] = useState<string>("");
+
+  const { user } = useContext(AuthContext);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+
+    if (name === "comment") {
+      setComment(value);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      if (post && post?.id) {
+        if (user?.uid) {
+          const commentObj = {
+            content: comment,
+            uid: user.uid,
+            email: user.email,
+            createdAt: new Date()?.toLocaleDateString("ko", {
+              hour: "2-digit",
+              minute: "2-digit",
+              second: "2-digit",
+            }),
+          };
+
+          await createComment(post.id, commentObj);
+
+          setComment("");
+        } else {
+          alert("로그인을 해주세요.");
+        }
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
   return (
     <div className={styles.comments}>
-      <form>
+      <form onSubmit={handleSubmit}>
         <div className={styles.form__block}>
-          <label>댓글입력</label>
-          <textarea />
+          <label htmlFor="comment">댓글입력</label>
+          <textarea
+            name="comment"
+            id="comment"
+            value={comment}
+            onChange={handleChange}
+            required
+          />
         </div>
         <button className={styles.comment__btn}>입력</button>
       </form>

--- a/src/components/Comments/Comments.tsx
+++ b/src/components/Comments/Comments.tsx
@@ -1,0 +1,13 @@
+export default function Comments() {
+  return (
+    <div>
+      <form>
+        <div>
+          <label>댓글입력</label>
+          <textarea />
+        </div>
+        <button>입력</button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/PostDetail/PostDetail.module.css
+++ b/src/components/PostDetail/PostDetail.module.css
@@ -83,9 +83,11 @@
 }
 
 .post__text {
+  min-height: 200px;
   color: #39211d;
   font-size: 17px;
   padding: 20px 0px;
+  border-bottom: 1px solid lightgray;
 }
 
 .post__text__preWrap {

--- a/src/components/PostDetail/PostDetail.tsx
+++ b/src/components/PostDetail/PostDetail.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router";
 import { deletePost, getPost } from "../../firebaseApp";
 import { useContext, useEffect, useState } from "react";
 import AuthContext from "../../context/AuthContext";
+import Comments from "../Comments/Comments";
 import { PostProps } from "../../typings/post.types";
 import styles from "./PostDetail.module.css";
 
@@ -57,6 +58,7 @@ export default function PostDetail() {
       <div className={`${styles.post__text} ${styles.post__text__preWrap}`}>
         {post?.content}
       </div>
+      <Comments />
     </div>
   );
 }

--- a/src/components/PostDetail/PostDetail.tsx
+++ b/src/components/PostDetail/PostDetail.tsx
@@ -1,12 +1,15 @@
 import { Link } from "react-router-dom";
 import { useNavigate, useParams } from "react-router";
 import { deletePost, getPost } from "../../firebaseApp";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
+import AuthContext from "../../context/AuthContext";
 import { PostProps } from "../../typings/post.types";
 import styles from "./PostDetail.module.css";
 
 export default function PostDetail() {
   const [post, setPost] = useState<PostProps | null>(null);
+
+  const { user } = useContext(AuthContext);
 
   const params = useParams();
   const navigate = useNavigate();
@@ -37,14 +40,18 @@ export default function PostDetail() {
       <div className={styles.post__utils__box}>
         <div className={styles.post__category}>{post?.category}</div>
         <div className={styles.post__edit__box}>
-          <div
-            className={styles.post__delete}
-            onClick={() => handleDelete(post?.id as string)}>
-            삭제
-          </div>
-          <div className={styles.post__edit}>
-            <Link to={`/posts/edit/${post?.id}`}>수정</Link>
-          </div>
+          {user && (
+            <>
+              <div
+                className={styles.post__delete}
+                onClick={() => handleDelete(post?.id as string)}>
+                삭제
+              </div>
+              <div className={styles.post__edit}>
+                <Link to={`/posts/edit/${post?.id}`}>수정</Link>
+              </div>
+            </>
+          )}
         </div>
       </div>
       <div className={`${styles.post__text} ${styles.post__text__preWrap}`}>

--- a/src/components/PostDetail/PostDetail.tsx
+++ b/src/components/PostDetail/PostDetail.tsx
@@ -58,7 +58,7 @@ export default function PostDetail() {
       <div className={`${styles.post__text} ${styles.post__text__preWrap}`}>
         {post?.content}
       </div>
-      <Comments />
+      <Comments post={post} setPost={setPost} />
     </div>
   );
 }

--- a/src/firebaseApp.ts
+++ b/src/firebaseApp.ts
@@ -8,6 +8,7 @@ import {
 } from "firebase/auth";
 import {
   addDoc,
+  arrayRemove,
   arrayUnion,
   collection,
   deleteDoc,
@@ -122,5 +123,13 @@ export async function createComment(id: string, commentObj: CommentsInterface) {
       minute: "2-digit",
       second: "2-digit",
     }),
+  });
+}
+
+export async function deleteComment(id: string, data: CommentsInterface) {
+  const postRef = doc(db, "posts", id);
+
+  await updateDoc(postRef, {
+    comments: arrayRemove(data),
   });
 }

--- a/src/firebaseApp.ts
+++ b/src/firebaseApp.ts
@@ -8,6 +8,7 @@ import {
 } from "firebase/auth";
 import {
   addDoc,
+  arrayUnion,
   collection,
   deleteDoc,
   doc,
@@ -15,7 +16,11 @@ import {
   getFirestore,
   updateDoc,
 } from "firebase/firestore";
-import { CategoryType, PostProps } from "./typings/post.types";
+import {
+  CategoryType,
+  CommentsInterface,
+  PostProps,
+} from "./typings/post.types";
 
 export let app: FirebaseApp;
 
@@ -105,4 +110,17 @@ export async function updatePost(
 
 export async function deletePost(id: string) {
   await deleteDoc(doc(db, "posts", id));
+}
+
+export async function createComment(id: string, commentObj: CommentsInterface) {
+  const postRef = doc(db, "posts", id);
+
+  await updateDoc(postRef, {
+    comments: arrayUnion(commentObj),
+    updatedAt: new Date()?.toLocaleDateString("ko", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }),
+  });
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,9 @@
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import ReactDOM from "react-dom/client";
-import React from "react";
 
 import App from "./App.tsx";
 import { AuthContextProvider } from "./context/AuthContext.tsx";
 import Home from "./pages/home/index.tsx";
-import PostPage from "./pages/posts/PostPage.tsx";
 import PostDetailPage from "./pages/posts/PostDetailPage.tsx";
 import PostEditPage from "./pages/posts/PostEditPage.tsx";
 import PostNewPage from "./pages/posts/PostNewPage.tsx";

--- a/src/typings/post.types.ts
+++ b/src/typings/post.types.ts
@@ -1,3 +1,5 @@
+import { User } from "firebase/auth";
+
 export const CATEGORIES: CategoryType[] = [
   "자유게시판",
   "Frontend",
@@ -33,4 +35,15 @@ export interface PostListProps {
   defaultTab?: TabType | CategoryType;
   activeTab?: TabType | CategoryType;
   handleChangeActiveTab?: (tab: CategoryType | TabType) => void;
+}
+
+export interface CommentsProps {
+  post: PostProps;
+  setPost: React.Dispatch<React.SetStateAction<PostProps | null>>;
+}
+
+export interface CommentListProps {
+  post: PostProps;
+  user: User | null;
+  handleDeleteComment: (data: CommentsInterface) => void;
 }

--- a/src/typings/post.types.ts
+++ b/src/typings/post.types.ts
@@ -9,6 +9,13 @@ export type CategoryType = "자유게시판" | "Frontend" | "Backend" | "web";
 
 export type TabType = "all" | "my";
 
+export interface CommentsInterface {
+  content: string;
+  uid: string;
+  email: string | null;
+  createdAt: string;
+}
+
 export interface PostProps {
   id?: string;
   title: string;
@@ -18,6 +25,7 @@ export interface PostProps {
   updatedAt?: string;
   uid: string;
   category?: CategoryType;
+  comments?: CommentsInterface[];
 }
 
 export interface PostListProps {


### PR DESCRIPTION
## 작업내용

1. 게시글 상세 페이지 댓글 기능 구현
- 비로그인 유저의 경우 댓글 작성 후 제출하면 로그인 페이지로 이동 
- 로그인 유저 댓글 등록 및 삭제 가능
- firebase의 posts 컬렉션 안에 comments를 추가해서 저장됨

  <br/>

## 이미지 첨부
<img width="1125" alt="스크린샷 2024-05-02 오후 4 01 42" src="https://github.com/jm-316/blog-project/assets/130331748/fd898c4f-2c91-4b28-95f3-1fc2a8574287">


<br/>

## 앞으로의 과제

- Not found page 수정

  <br/>
